### PR TITLE
Added Missing Installation Step

### DIFF
--- a/pages/docs/symfony.md
+++ b/pages/docs/symfony.md
@@ -16,6 +16,21 @@ In your Symfony application directory, run:
 
 `composer require amyboyd/mongrate-bundle`
 
+Add the bundle to registerBundles() method of AppKernel:
+
+```
+# app/AppKernel.php
+
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = array(
+            ...
+            new Mongrate\MongrateBundle\MongrateBundle(),
+            ...
+```
+
 Set your configuration in your application's `config.yml`:
 
 <pre>


### PR DESCRIPTION
There were no information about the bundle registration in Symfony application kernel. Though it's obvious for any experienced symfony user, it should be mentioned in docs.

P.S. My English can be creepy sometimes, feel free to let me know if anything is wrong in the doc's update. 
